### PR TITLE
Add benchmark comparing join of gen expression vs join of list comp

### DIFF
--- a/bench_comprehensions.py
+++ b/bench_comprehensions.py
@@ -9,7 +9,17 @@ def filter_list_as_comprehension():
     inputs = range(100_000)
     result = [i for i in inputs if i % 2]
 
+def join_generator_expression():
+    words = ['data', 'type', 'is', 'so', 'long', 'now']
+    for x in range(100_000):
+        ''.join(ele.title() for ele in words)
+
+def join_list_comprehension():
+    words = ['data', 'type', 'is', 'so', 'long', 'now']
+    for x in range(100_000):
+        ''.join([ele.title() for ele in words])
 
 __benchmarks__ = [
     (filter_list_as_loop, filter_list_as_comprehension, "Using a list comprehension to filter another list"),
+    (join_generator_expression, join_list_comprehension, "Join list comprehension instead of generator expression"),
 ]


### PR DESCRIPTION
Typically generator expressions are supposed to be more performance, but apparently str.join converts an iterable arg to a list anyway, if its not yet, so generator expressions add an overhead for conversion.

https://stackoverflow.com/questions/37782066/list-vs-generator-comprehension-speed-with-join-function
Current source code:
https://github.com/python/cpython/blob/main/Objects/unicodeobject.c#L9375

In my scalene tests, performance is better for the list comprehension version. This benchmark should show that as well, though I'm not sure if I've formatted it correctly.

