### PR TITLE
Add a benchmark for regex related practices

### DIFF
--- a/bench_regex.py
+++ b/bench_regex.py
@@ -1,0 +1,35 @@
+import re
+
+def regex_with_anchors():
+    SNAKE_CASE_RE = re.compile(r'^([a-z]+\d*_[a-z\d_]*|_+[a-z\d]+[a-z\d_]*)$')
+    tests = ['data_type', 'data_type_', '_dataType', 'dataType', 'data type']
+    for x in range(100_000):
+        for test_str in tests:
+            SNAKE_CASE_RE.match(test_str)
+
+def regex_with_fullmatch():
+    SNAKE_CASE_RE = re.compile(r'([a-z]+\d*_[a-z\d_]*|_+[a-z\d]+[a-z\d_]*)')
+    tests = ['data_type', 'data_type_', '_dataType', 'dataType', 'data type']
+    for x in range(100_000):
+        for test_str in tests:
+            SNAKE_CASE_RE.fullmatch(test_str)
+
+def regex_with_ignorecase():
+    SNAKE_CASE_RE = re.compile(r'([a-z]+\d*_[a-z\d_]*|_+[a-z\d]+[a-z\d_]*)', re.IGNORECASE)
+    tests = ['data_type', 'data_type_URL', '_DataType', 'DataTypeURL', 'Data Type URL']
+    for x in range(100_000):
+        for test_str in tests:
+            SNAKE_CASE_RE.fullmatch(test_str)
+
+def regex_with_capitalrange():
+    SNAKE_CASE_RE = re.compile(r'([a-zA-Z]+\d*_[a-zA-Z\d_]*|_+[a-zA-Z\d]+[a-zA-Z\d_]*)')
+    tests = ['data_type', 'data_type_URL', '_DataType', 'DataTypeURL', 'Data Type URL']
+    for x in range(100_000):
+        for test_str in tests:
+            SNAKE_CASE_RE.fullmatch(test_str)
+
+
+__benchmarks__ = [
+    (regex_with_anchors, regex_with_fullmatch, "Using fullmatch instead of anchors"),
+    (regex_with_ignorecase, regex_with_capitalrange, "Using a-zA-Z instead of IGNORECASE"),
+]


### PR DESCRIPTION
The first benchmark compares a regex with start/end anchors and the match method versus a regex with no anchors and the fullmatch method. I believe those should be equivalent functionally and was curious if the performance would vary. I do generally see better performance on the second, but it's usually below 10%, and its not always better, so maybe that benchmark should be thrown away?

The second benchmark compares using re.IGNORECASE with a regex looking for [a-z] versus a regex that specifies [a-zA-Z ] but has no flag. That seems to reliably get good performance improvements (~20-25%).